### PR TITLE
Notify our bot locally

### DIFF
--- a/lib/capistrano/tasks/notifications.rake
+++ b/lib/capistrano/tasks/notifications.rake
@@ -2,13 +2,18 @@ namespace :sumo do
   namespace :notifications do
     desc 'Notify our webhooks on a deploy'
     task :deploy do
+      # fetch the revision from the web-server
       on roles(:web) do
+        set :revision, capture("cat #{current_path}/REVISION")
+      end
+
+      run_locally do
         execute :curl,
                 '-sS',
                 "--data local_username=#{ENV["USER"]}",
                 "--data stage=#{fetch(:stage)}",
                 "--data repo=#{fetch(:repo_url)}",
-                "--data revision=#{capture("cat #{current_path}/REVISION")}",
+                "--data revision=#{fetch(:revision)}",
                 'http://bot.sumo.sumoapp.be:3001/deploy/hook'
       end
     end


### PR DESCRIPTION
In some cases port 3001 is blocked so this task triggerd an errors, which
caused a rollback.

Instead of executing the call on the server we do it locally, so we are
sure the port is not blocked.