### PR TITLE
Encapsulate database option values in quotes

### DIFF
--- a/lib/capistrano/tasks/db.rake
+++ b/lib/capistrano/tasks/db.rake
@@ -95,7 +95,7 @@ namespace :sumo do
       options = ''
 
       data.each do |key, value|
-        options << "--#{key}=#{value} " unless value.empty?
+        options << "--#{key}=\"#{value}\" " unless value.empty?
       end
       options
     end


### PR DESCRIPTION
This makes sure nothing breaks when using weird password characters for example